### PR TITLE
Genius child alice/feature/following feed

### DIFF
--- a/src/controller/FeedController.ts
+++ b/src/controller/FeedController.ts
@@ -254,7 +254,7 @@ export const getFeedGroupListController = async (ctx: koaCtx, next: koaNext) => 
 }
 
 /**
- * 获取动态内容
+ * 获取动态内容（关注推送流）
  * @param ctx context
  * @param next context
  * @return 获取动态内容的请求响应
@@ -266,9 +266,15 @@ export const getFeedContentController = async (ctx: koaCtx, next: koaNext) => {
 	const page = ctx.query.page as string
 	const pageSize = ctx.query.pageSize as string
 	const finalPageSize = limitPageSize(pageSize)
+	const feedGroupUuid = (ctx.query.feedGroupUuid as string | undefined)?.trim() || undefined
+	const followingUidRaw = ctx.query.followingUid as string | undefined
+	const followingUid = followingUidRaw !== undefined && followingUidRaw !== null && String(followingUidRaw).trim() !== ''
+		? parseInteger(followingUidRaw)
+		: undefined
 
 	const getFeedContentRequest: GetFeedContentRequestDto = {
-		feedGroupUuid: uuid ?? "",
+		feedGroupUuid,
+		followingUid: followingUid !== undefined && !Number.isNaN(followingUid) ? followingUid : undefined,
 		pagination: {
 			page: parseInteger(page || '1') ?? 1,
 			pageSize: finalPageSize ?? 50,

--- a/src/controller/FeedControllerDto.ts
+++ b/src/controller/FeedControllerDto.ts
@@ -255,9 +255,16 @@ export type GetFeedGroupListResponseDto = {
 
 /**
  * 获取动态内容的请求载荷
+ * 三种互斥模式：
+ * 1. 不传 feedGroupUuid / followingUid → 全部关注用户的推送流
+ * 2. 传 feedGroupUuid → 指定关注分组内用户的推送流
+ * 3. 传 followingUid → 指定单个已关注用户的推送流
  */
 export type GetFeedContentRequestDto = {
+	/** 动态分组 UUID（可选，与 followingUid 互斥） */
 	feedGroupUuid?: string;
+	/** 单个关注用户的 UID（可选，与 feedGroupUuid 互斥） */
+	followingUid?: number;
 	/** 分页查询 */
 	pagination: {
 		/** 当前在第几页 */

--- a/src/route/router.ts
+++ b/src/route/router.ts
@@ -754,12 +754,16 @@ router.get('/feed/getFeedGroupList', getFeedGroupListController) // 获取动态
 // cookie: uuid, token
 
 
-router.get('/feed/getFeedContent', getFeedContentController) // 获取动态分组
+router.get('/feed/getFeedContent', getFeedContentController) // 获取关注推送流（全部关注 / 分组 / 单用户）
 // https://localhost:30000/feed/getFeedContent?page=1&pageSize=30
+// https://localhost:30000/feed/getFeedContent?feedGroupUuid=xxxxxxxxxxxxxxxxxxxxx&page=1&pageSize=30
+// https://localhost:30000/feed/getFeedContent?followingUid=999&page=1&pageSize=30
 // cookie: uuid, token
-// {
-// 	"feedGroupUuid": "xxxxxxxxxxxxxxxxxxxxx"
-// }
+// Query:
+// feedGroupUuid（可选，与 followingUid 互斥）
+// followingUid（可选，与 feedGroupUuid 互斥）
+// page
+// pageSize
 
 router.get('/feed/stats', getFollowStatsController) // 获取用户关注数和粉丝数
 // https://localhost:30000/feed/stats?targetUid=999

--- a/src/service/FeedService.ts
+++ b/src/service/FeedService.ts
@@ -729,7 +729,8 @@ export const getFeedGroupListService = async (uuid: string, token: string): Prom
 }
 
 /**
- * 获取动态内容
+ * 获取动态内容（关注推送流）
+ * 支持：全部关注 / 指定关注分组 / 指定单个已关注用户；仅返回 pushToFeed 为 true 的视频
  * @param getFeedContentRequest 获取动态内容的请求载荷
  * @param uuid 用户的 UUID
  * @param token 用户的 token
@@ -742,40 +743,76 @@ export const getFeedContentService = async (getFeedContentRequest: GetFeedConten
 			return { success: false, message: '获取动态内容失败，参数不合法', isLonely: false }
 		}
 
-		if (!(await checkUserTokenByUuidService(uuid, uuid)).success) {
+		if (!(await checkUserTokenByUuidService(uuid, token)).success) {
 			logging('ERROR', '获取动态内容失败，非法用户')
 			return { success: false, message: '获取动态内容失败，非法用户', isLonely: false }
 		}
 
-		const { feedGroupUuid, pagination } = getFeedContentRequest
+		const { feedGroupUuid, followingUid, pagination } = getFeedContentRequest
+		let uploaderUuidList: string[] = []
 
-		const uuidList = []
 		if (feedGroupUuid) {
 			const { collectionName: feedGroupCollectionName, schemaInstance: feedGroupSchemaInstance } = FeedGroupSchema
 			type FeedGroup = InferSchemaType<typeof feedGroupSchemaInstance>
 
 			const getFeedGroupUuidListWhere: QueryType<FeedGroup> = {
 				feedGroupUuid,
+				feedGroupCreatorUuid: uuid, // 仅允许读取自己创建的分组
 			}
 
 			const getFeedGroupUuidListSelect: SelectType<FeedGroup> = {
-				uuidList: 1, // 动态分组中的用户
+				uuidList: 1,
 			}
 
 			const getFeedGroupUserListResult = await selectDataFromMongoDB<FeedGroup>(getFeedGroupUuidListWhere, getFeedGroupUuidListSelect, feedGroupSchemaInstance, feedGroupCollectionName)
-			const uuidListResult = getFeedGroupUserListResult.result?.[0]?.uuidList
-
 			if (!getFeedGroupUserListResult.success) {
 				logging('ERROR', '获取动态内容失败，查询动态分组中的用户失败')
-				return { success: false, message: '获取动态内容失败，查询动态分组中的用户失败', isLonely: { noUserInFeedGroup: true } }
+				return { success: false, message: '获取动态内容失败，查询动态分组中的用户失败', isLonely: false }
 			}
 
-			if (Array.isArray(uuidListResult) && uuidList.length <= 0) {
-				logging('WARN', '你选择动态分组中没有用户')
-				return { success: true, message: '你选择动态分组中没有用户', isLonely: { noUserInFeedGroup: true }, result: { count: 0, content: [] } }
+			const feedGroup = getFeedGroupUserListResult.result?.[0]
+			if (!feedGroup) {
+				logging('ERROR', '获取动态内容失败，动态分组不存在或无权访问')
+				return { success: false, message: '获取动态内容失败，动态分组不存在或无权访问', isLonely: false }
 			}
 
-			uuidList.push(uuidListResult)
+			const uuidListResult = feedGroup.uuidList
+			if (!Array.isArray(uuidListResult) || uuidListResult.length <= 0) {
+				logging('WARN', '你选择的动态分组中没有用户')
+				return { success: true, message: '你选择的动态分组中没有用户', isLonely: { noUserInFeedGroup: true }, result: { count: 0, content: [] } }
+			}
+
+			uploaderUuidList = uuidListResult
+		} else if (followingUid !== undefined && followingUid !== null) {
+			const followingUuid = await getUserUuid(followingUid)
+			if (!followingUuid) {
+				logging('ERROR', '获取动态内容失败，目标用户不存在')
+				return { success: false, message: '获取动态内容失败，目标用户不存在', isLonely: false }
+			}
+
+			const { collectionName: followingCollectionName, schemaInstance: followingSchemaInstance } = FollowingSchema
+			type Following = InferSchemaType<typeof followingSchemaInstance>
+
+			const getFollowingWhere: QueryType<Following> = {
+				followerUuid: uuid,
+				followingUuid,
+			}
+			const getFollowingSelect: SelectType<Following> = {
+				followingUuid: 1,
+			}
+
+			const getFollowingResult = await selectDataFromMongoDB<Following>(getFollowingWhere, getFollowingSelect, followingSchemaInstance, followingCollectionName)
+			if (!getFollowingResult.success) {
+				logging('ERROR', '获取动态内容失败，查询关注关系失败')
+				return { success: false, message: '获取动态内容失败，查询关注关系失败', isLonely: false }
+			}
+
+			if (!getFollowingResult.result || getFollowingResult.result.length <= 0) {
+				logging('WARN', '获取动态内容失败，你未关注该用户')
+				return { success: false, message: '获取动态内容失败，你未关注该用户', isLonely: { noFollowing: true } }
+			}
+
+			uploaderUuidList = [followingUuid]
 		} else {
 			const { collectionName: followingCollectionName, schemaInstance: followingSchemaInstance } = FollowingSchema
 			type Following = InferSchemaType<typeof followingSchemaInstance>
@@ -783,52 +820,53 @@ export const getFeedContentService = async (getFeedContentRequest: GetFeedConten
 			const getFollowingUuidListWhere: QueryType<Following> = {
 				followerUuid: uuid,
 			}
-
 			const getFollowingUuidListSelect: SelectType<Following> = {
 				followingUuid: 1,
 			}
 
 			const getFollowingUserListResult = await selectDataFromMongoDB<Following>(getFollowingUuidListWhere, getFollowingUuidListSelect, followingSchemaInstance, followingCollectionName)
-			const uuidListResult = getFollowingUserListResult.result?.map(followingResult => followingResult.followingUuid)
-
 			if (!getFollowingUserListResult.success) {
 				logging('ERROR', '获取动态内容失败，查询用户关注的用户失败')
-				return { success: false, message: '获取动态内容失败，查询用户关注的用户失败', isLonely: { noFollowing: true } }
+				return { success: false, message: '获取动态内容失败，查询用户关注的用户失败', isLonely: false }
 			}
 
-			if (Array.isArray(uuidListResult) && uuidList.length <= 0) {
+			const uuidListResult = getFollowingUserListResult.result?.map(followingResult => followingResult.followingUuid) ?? []
+			if (uuidListResult.length <= 0) {
 				logging('WARN', '你没有关注任何用户')
 				return { success: true, message: '你没有关注任何用户', isLonely: { noFollowing: true }, result: { count: 0, content: [] } }
 			}
 
-			uuidList.push(uuidListResult)
+			uploaderUuidList = uuidListResult
 		}
 
-		// 根据 uuid 匹配视频的基础 pipeline
+		const skip = (pagination.page - 1) * pagination.pageSize
+		const pageSize = pagination.pageSize
+
+		// 仅推送允许进入动态流的视频
 		const feedContentMatchPipeline: PipelineStage[] = [
 			{
 				$match: {
-					uploaderUUID: { $in: uuidList },
+					uploaderUUID: { $in: uploaderUuidList },
+					pushToFeed: true,
+					pendingReview: false,
 				},
 			},
 		]
 
-		// 获取动态视频总数的 pipeline
-		const countFeedContentBasePipeline: PipelineStage[] = [
+		const countFeedContentPipeline: PipelineStage[] = feedContentMatchPipeline.concat([
 			{
-				$count: 'totalCount', // 统计总文档数
-			}
-		]
+				$count: 'totalCount',
+			},
+		])
 
-		let skip = 0
-		let pageSize = undefined
-		if (pagination && pagination.page > 0 && pagination.pageSize > 0) {
-			skip = (pagination.page - 1) * pagination.pageSize
-			pageSize = pagination.pageSize
-		}
-
-		// 匹配视频信息的 pipeline
-		const getFeedContentBasePipeline: PipelineStage[] = [
+		const getFeedContentPipeline: PipelineStage[] = feedContentMatchPipeline.concat([
+			{
+				$sort: {
+					uploadDate: -1,
+				},
+			},
+			{ $skip: skip },
+			{ $limit: pageSize },
 			{
 				$lookup: {
 					from: 'user-infos',
@@ -837,15 +875,8 @@ export const getFeedContentService = async (getFeedContentRequest: GetFeedConten
 					as: 'uploader_info',
 				},
 			},
-			{ $skip: skip }, // 跳过指定数量的文档
-			{ $limit: pageSize }, // 限制返回的文档数量
 			{
 				$unwind: '$uploader_info',
-			},
-			{
-				$sort: {
-					uploadDate: -1, // 按 uploadDate 降序排序
-				},
 			},
 			{
 				$project: {
@@ -854,33 +885,28 @@ export const getFeedContentService = async (getFeedContentRequest: GetFeedConten
 					image: 1,
 					uploadDate: 1,
 					watchedCount: 1,
-					uploaderId: 1, // 上传者 UID
+					uploaderId: 1,
 					duration: 1,
 					description: 1,
 					editDateTime: 1,
-					uploader: '$uploader_info.username', // 上传者的名字
-					uploaderNickname: '$uploader_info.userNickname', // 上传者的昵称
-				}
-			}
-		]
-
-		const countFeedContentPipeline = feedContentMatchPipeline.concat(countFeedContentBasePipeline)
-		const getFeedContentPipeline = feedContentMatchPipeline.concat(getFeedContentBasePipeline)
+					uploader: '$uploader_info.username',
+					uploaderNickname: '$uploader_info.userNickname',
+				},
+			},
+		])
 
 		const { collectionName: videoCollectionName, schemaInstance: videoSchemaInstance } = VideoSchema
 		type ThumbVideo = InferSchemaType<typeof videoSchemaInstance>
 
-		const feedContentCountPromise = selectDataByAggregateFromMongoDB(videoSchemaInstance, videoCollectionName, countFeedContentPipeline)
-		const feedContentDataPromise = selectDataByAggregateFromMongoDB<ThumbVideo>(videoSchemaInstance, videoCollectionName, getFeedContentPipeline)
+		const [feedContentCountResult, feedContentDataResult] = await Promise.all([
+			selectDataByAggregateFromMongoDB(videoSchemaInstance, videoCollectionName, countFeedContentPipeline),
+			selectDataByAggregateFromMongoDB<ThumbVideo>(videoSchemaInstance, videoCollectionName, getFeedContentPipeline),
+		])
 
-		const [ feedContentCountResult, feedContentDataResult ] = await Promise.all([feedContentCountPromise, feedContentDataPromise])
-		const count = feedContentCountResult.result?.[0]?.totalCount
-		const content = feedContentDataResult.result
+		const count = feedContentCountResult.result?.[0]?.totalCount ?? 0
+		const content = feedContentDataResult.result ?? []
 
-		if ( !feedContentCountResult.success || !feedContentDataResult.success
-			|| typeof count !== 'number' || count < 0
-			|| ( Array.isArray(content) && !content )
-		) {
+		if (!feedContentCountResult.success || !feedContentDataResult.success || typeof count !== 'number' || count < 0 || !Array.isArray(content)) {
 			logging('ERROR', '获取动态内容失败，查询视频数据失败')
 			return { success: false, message: '获取动态内容失败，查询视频数据失败', isLonely: false }
 		}
@@ -1265,10 +1291,27 @@ const checkAdministratorDeleteFeedGroupRequest = (administratorDeleteFeedGroupRe
  * @returns 合法返回 true, 不合法返回 false
  */
 const checkGetFeedContentRequest = (getFeedContentRequest: GetFeedContentRequestDto): boolean => {
+	const { feedGroupUuid, followingUid, pagination } = getFeedContentRequest
+
+	// feedGroupUuid 与 followingUid 互斥
+	if (feedGroupUuid && followingUid !== undefined && followingUid !== null) {
+		return false
+	}
+
+	if (followingUid !== undefined && followingUid !== null && (!(typeof followingUid === 'number') || Number.isNaN(followingUid) || followingUid <= 0)) {
+		return false
+	}
+
+	if (feedGroupUuid !== undefined && feedGroupUuid !== null && typeof feedGroupUuid === 'string' && feedGroupUuid.trim() === '') {
+		return false
+	}
+
 	return (
-		!!getFeedContentRequest.pagination
-		&& getFeedContentRequest.pagination.page >= 0 && getFeedContentRequest.pagination.pageSize > 0 && getFeedContentRequest.pagination.pageSize <= 200
-	);
+		!!pagination
+		&& pagination.page >= 1
+		&& pagination.pageSize > 0
+		&& pagination.pageSize <= 200
+	)
 }
 
 /**

--- a/src/service/FeedService.ts
+++ b/src/service/FeedService.ts
@@ -11,6 +11,7 @@ import { v4 as uuidV4 } from 'uuid'
 import { generateSecureRandomString } from "../common/RandomTool.js";
 import { createCloudflareImageUploadSignedUrl } from "../cloudflare/index.js";
 import { VideoSchema } from "../dbPool/schema/VideoSchema.js";
+import { BlockListSchema } from "../dbPool/schema/BlockSchema.js";
 import { logging } from "./loggingService.js";
 
 /**
@@ -839,10 +840,22 @@ export const getFeedContentService = async (getFeedContentRequest: GetFeedConten
 			uploaderUuidList = uuidListResult
 		}
 
+		// 过滤：我拉黑的人 + 拉黑我的人（双向屏蔽，不进入推送流）
+		const filteredUploaderUuidList = await filterBlockedUploaderUuidsForFeed(uploaderUuidList, uuid)
+		if (!filteredUploaderUuidList.success) {
+			logging('ERROR', '获取动态内容失败，过滤屏蔽关系失败')
+			return { success: false, message: '获取动态内容失败，过滤屏蔽关系失败', isLonely: false }
+		}
+		uploaderUuidList = filteredUploaderUuidList.uploaderUuidList
+		if (uploaderUuidList.length <= 0) {
+			logging('WARN', '过滤屏蔽关系后，没有可展示的推送用户')
+			return { success: true, message: '获取动态内容成功，长度为零', isLonely: false, result: { count: 0, content: [] } }
+		}
+
 		const skip = (pagination.page - 1) * pagination.pageSize
 		const pageSize = pagination.pageSize
 
-		// 仅推送允许进入动态流的视频
+		// 仅推送允许进入动态流、且已通过审核的视频
 		const feedContentMatchPipeline: PipelineStage[] = [
 			{
 				$match: {
@@ -1283,6 +1296,68 @@ const checkAdministratorApproveFeedGroupInfoChangeRequest = (administratorApprov
  */
 const checkAdministratorDeleteFeedGroupRequest = (administratorDeleteFeedGroupRequest: AdministratorDeleteFeedGroupRequestDto): boolean => {
 	return ( !!administratorDeleteFeedGroupRequest.feedGroupUuid )
+}
+
+/**
+ * 从推送流候选 UP 主 UUID 列表中，排除「我拉黑的人」和「拉黑我的人」
+ * @param uploaderUuidList 候选上传者 UUID 列表
+ * @param viewerUuid 当前查看者 UUID
+ * @returns 过滤结果；查询失败时 success 为 false
+ */
+const filterBlockedUploaderUuidsForFeed = async (uploaderUuidList: string[], viewerUuid: string): Promise<{ success: boolean, uploaderUuidList: string[] }> => {
+	if (!uploaderUuidList.length) {
+		return { success: true, uploaderUuidList }
+	}
+
+	const { collectionName: blockListCollectionName, schemaInstance: blockListSchemaInstance } = BlockListSchema
+	type BlockList = InferSchemaType<typeof blockListSchemaInstance>
+
+	const blockedByMeWhere: QueryType<BlockList> = {
+		operatorUUID: viewerUuid,
+		type: 'block',
+	}
+	const blockedByMeSelect: SelectType<BlockList> = {
+		value: 1,
+	}
+
+	const blockedMeWhere: QueryType<BlockList> = {
+		value: viewerUuid,
+		type: 'block',
+	}
+	const blockedMeSelect: SelectType<BlockList> = {
+		operatorUUID: 1,
+	}
+
+	const [blockedByMeResult, blockedMeResult] = await Promise.all([
+		selectDataFromMongoDB<BlockList>(blockedByMeWhere, blockedByMeSelect, blockListSchemaInstance, blockListCollectionName),
+		selectDataFromMongoDB<BlockList>(blockedMeWhere, blockedMeSelect, blockListSchemaInstance, blockListCollectionName),
+	])
+
+	if (!blockedByMeResult.success || !blockedMeResult.success) {
+		logging('ERROR', '过滤推送流屏蔽关系失败，查询黑名单失败')
+		return { success: false, uploaderUuidList: [] }
+	}
+
+	const excludedUuidSet = new Set<string>()
+	for (const item of blockedByMeResult.result ?? []) {
+		if (item.value) {
+			excludedUuidSet.add(item.value)
+		}
+	}
+	for (const item of blockedMeResult.result ?? []) {
+		if (item.operatorUUID) {
+			excludedUuidSet.add(item.operatorUUID)
+		}
+	}
+
+	if (excludedUuidSet.size <= 0) {
+		return { success: true, uploaderUuidList }
+	}
+
+	return {
+		success: true,
+		uploaderUuidList: uploaderUuidList.filter(uploaderUuid => !excludedUuidSet.has(uploaderUuid)),
+	}
 }
 
 /**


### PR DESCRIPTION
# 完善关注推送流（getFeedContent）

## Summary

- 修复并完善 `GET /feed/getFeedContent`，使其成为可用的关注视频推送流接口。
- 支持三种拉取模式：全部关注、按关注分组、按单个已关注用户。
- 过滤仅允许推送到动态的视频（`pushToFeed: true`）、待审核视频（`pendingReview: false`），以及双向拉黑用户的内容。

## Background

原有 `getFeedContent` 已有骨架（关注列表 / 动态分组 → 查视频），但实现不可用，主要问题包括：

- Controller 误把 cookie 中的用户 `uuid` 当作 `feedGroupUuid`
- Token 校验写成 `checkUserTokenByUuidService(uuid, uuid)`
- 关注 UUID 列表拼装 / 空列表判断错误，`$in` 可能嵌套数组
- 聚合分页顺序错误（`$skip`/`$limit` 在 `$sort` 之前）
- 未按 `pushToFeed`、待审核、拉黑关系过滤

周边能力（关注 / 取消关注、动态分组 CRUD、视频 `pushToFeed` 字段）此前已具备，本次以修复并补全该消费接口为主。

## Changes

### API

`GET /feed/getFeedContent`

| 模式 | Query 示例 |
|------|------------|
| 全部关注 | `?page=1&pageSize=30` |
| 按分组 | `?feedGroupUuid=<uuid>&page=1&pageSize=30` |
| 按单用户 | `?followingUid=999&page=1&pageSize=30` |

- Cookie：`uuid`、`token`（需登录）
- `feedGroupUuid` 与 `followingUid` **互斥**
- `pageSize` 经 `limitPageSize` 限制

### 行为要点

1. **鉴权**：校验当前用户 token。
2. **候选 UP 主**：
   - 无额外参数 → 当前用户全部关注；
   - `feedGroupUuid` → 仅自己创建的分组内用户；
   - `followingUid` → 必须已关注该用户。
3. **双向拉黑**：排除「我拉黑的人」与「拉黑我的人」。
4. **视频过滤**：`pushToFeed: true` 且 `pendingReview: false`。
5. **分页**：先过滤再 `$sort(uploadDate desc)` → `$skip` / `$limit`，尽量返回满页；`result.count` 为过滤后总数。

### 涉及文件

- `src/controller/FeedControllerDto.ts` — 请求 DTO 增加 `followingUid`，明确三种模式
- `src/controller/FeedController.ts` — 正确从 query 解析参数
- `src/route/router.ts` — 路由注释与用法示例
- `src/service/FeedService.ts` — 重写 `getFeedContentService`，新增双向拉黑过滤辅助函数与参数校验

## Test plan

- [ ] 未登录 / 错误 cookie → 返回非法用户
- [ ] 无关注用户 → `success: true`，`isLonely.noFollowing`，内容为空
- [ ] 全部关注：仅出现 `pushToFeed: true` 且已过审视频；`pushToFeed: false` / 待审不出现
- [ ] 拉黑对方后，对方内容不再出现在推送流
- [ ] 被对方拉黑后，对方内容不再出现在推送流
- [ ] `feedGroupUuid`：仅自己的分组可读；空分组 → `isLonely.noUserInFeedGroup`
- [ ] `followingUid`：未关注目标 → 失败；已关注 → 仅该用户内容
- [ ] 同时传 `feedGroupUuid` 与 `followingUid` → 参数不合法
- [ ] 分页：`page` / `pageSize` 正常；有足够数据时当页接近 `pageSize`；`count` 与过滤后总数一致

## Commits

- `0c1d975` ✨ 🐛 完善 getFeedContent：全部关注、分组、单用户拉取，并过滤 pushToFeed
- `0d5f659` 🚸 关注推送流排除双向拉黑用户内容

## Notes

- Feed 读接口未加 RBAC，与同模块 `getFeedGroupList` / `getFollowingList` 等一致。
- 未接入 `buildBlockListMongooseFilter`（首页用的聚合过滤器）；本接口在查视频前对候选 UUID 做预过滤，更适合关注流分页与计数一致。
- 暂未过滤 hide / 关键词 / tag；若产品需要与首页黑名单策略完全对齐，可后续再补。
- 性能：关注量很大时 `$in` 会变大；后续可考虑补索引、`$facet` 合并 count/list、游标分页等优化。
